### PR TITLE
ci: allow read access to models

### DIFF
--- a/.github/workflows/policy_watch.yml
+++ b/.github/workflows/policy_watch.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   issues: write
+  models: read
 
 jobs:
   watch:


### PR DESCRIPTION
## Summary
- allow the Policy Watch workflow to read models

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b33d8d0fec8331b271f5fc44c5f445