### PR TITLE
feat: chunk grok diff requests

### DIFF
--- a/.github/workflows/policy_watch.yml
+++ b/.github/workflows/policy_watch.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   issues: write
+  models: read # allow workflows to access models
 
 jobs:
   watch:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ lxml
 azure-ai-inference
 feedparser
 requests
+tiktoken


### PR DESCRIPTION
## Summary
- clarify `models: read` permission in Policy Watch workflow
- chunk grok diff requests to stay under model token limits

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python scripts/grok-diff.py` *(fails: ClientAuthenticationError: Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_68b33d8d0fec8331b271f5fc44c5f445