### PR TITLE
feat: fallback to instrument feeds when main TBS latest-changes feed is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Updates over time are added to `items.csv` along with the GUID assigned, so a di
 ## Features
 
 ✅ Fetch and parse the RSS feed for new policy items  
+✅ Automatically fallback to instrument-specific feeds when the main latest-changes feed is unavailable  
 ✅ Append new items to `data/items.csv`  
 ✅ Create GitHub Issues for new items  
 ✅ Archive XML documents for **Framework**, **Policy**, **Directive**, **Standard**, and **Guideline** categories
@@ -62,4 +63,3 @@ The workflow runs on a schedule to:
 │ ├── policy_watch.yml
 │ ├── init_xml_archives.yml
 ```
-

--- a/scripts/fetch_feed.py
+++ b/scripts/fetch_feed.py
@@ -5,9 +5,17 @@ import requests
 import feedparser
 from bs4 import BeautifulSoup
 from datetime import datetime
+from email.utils import parsedate_to_datetime
 
 # --- Configuration ---
 RSS_URL = "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=2&count=100"
+FALLBACK_RSS_URLS = [
+    "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=1&type=79",
+    "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=1&type=27",
+    "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=1&type=73",
+    "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=1&type=36",
+    "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=1&type=83",
+]
 DATA_DIR = "data"
 ITEMS_CSV_PATH = os.path.join(DATA_DIR, "items.csv")
 NEW_ITEMS_CSV_PATH = os.path.join(DATA_DIR, "new_items.csv")
@@ -24,6 +32,64 @@ def sanitize_filename(name):
     """Sanitize a string to be a valid filename."""
     name = name.replace(":", "_").replace("/", "_")
     return "".join(c for c in name if c.isalnum() or c in (' ', '.', '_', '-')).rstrip()
+
+
+def parse_pub_date(pub_date):
+    """Convert an RSS date string to a comparable datetime value."""
+    if not pub_date:
+        return datetime.min
+    try:
+        return parsedate_to_datetime(pub_date)
+    except (TypeError, ValueError):
+        return datetime.min
+
+
+def normalize_entry(entry):
+    """Normalize feedparser entries into a stable dictionary structure."""
+    guid = entry.get('guid') or entry.get('id') or entry.get('link')
+    return {
+        "guid": guid,
+        "title": entry.get('title', '').strip(),
+        "link": entry.get('link', '').strip(),
+        "pubDate": entry.get('published', ''),
+        "category": entry.get('category', 'Uncategorized'),
+    }
+
+
+def fetch_entries_with_fallback(parser=feedparser.parse):
+    """Fetch entries from primary feed; use instrument feeds if main feed is unavailable."""
+    primary_feed = parser(RSS_URL)
+    primary_entries = getattr(primary_feed, 'entries', [])
+
+    if not getattr(primary_feed, 'bozo', False) and primary_entries:
+        return [normalize_entry(entry) for entry in primary_entries], "primary"
+
+    if getattr(primary_feed, 'bozo', False):
+        print(f"Warning: main RSS feed appears broken ({primary_feed.bozo_exception}). Falling back to instrument feeds.")
+    else:
+        print("Warning: main RSS feed returned no entries. Falling back to instrument feeds.")
+
+    deduped_entries = {}
+    for feed_url in FALLBACK_RSS_URLS:
+        fallback_feed = parser(feed_url)
+        if getattr(fallback_feed, 'bozo', False):
+            print(f"Warning: fallback feed parse issue for {feed_url}: {fallback_feed.bozo_exception}")
+            continue
+        for entry in getattr(fallback_feed, 'entries', []):
+            normalized = normalize_entry(entry)
+            guid = normalized['guid']
+            if not guid:
+                continue
+            existing = deduped_entries.get(guid)
+            if not existing or parse_pub_date(normalized['pubDate']) > parse_pub_date(existing['pubDate']):
+                deduped_entries[guid] = normalized
+
+    sorted_entries = sorted(
+        deduped_entries.values(),
+        key=lambda e: parse_pub_date(e['pubDate']),
+        reverse=True,
+    )
+    return sorted_entries, "fallback"
 
 def get_existing_guids(filepath):
     """Reads the existing CSV file and returns a set of GUIDs."""
@@ -96,21 +162,22 @@ def main():
     existing_guids = get_existing_guids(ITEMS_CSV_PATH)
     print(f"Found {len(existing_guids)} existing policy documents.")
 
-    feed = feedparser.parse(RSS_URL)
-    if feed.bozo:
-        print(f"Error parsing RSS feed: {feed.bozo_exception}")
+    entries, source = fetch_entries_with_fallback()
+    if not entries:
+        print("Error: unable to fetch entries from both main and fallback RSS feeds.")
         return
+    print(f"Using {source} feed source with {len(entries)} entries.")
 
     new_items = []
-    for entry in feed.entries:
-        if entry.guid not in existing_guids:
-            print(f"New item found: {entry.title} ({entry.guid})")
-            category = entry.get('category', 'Uncategorized')
-            filename = download_policy_xml(entry.link, category, entry.title, entry.published)
+    for entry in entries:
+        if entry['guid'] not in existing_guids:
+            print(f"New item found: {entry['title']} ({entry['guid']})")
+            category = entry['category']
+            filename = download_policy_xml(entry['link'], category, entry['title'], entry['pubDate'])
             if filename:
                 new_items.append({
-                    "guid": entry.guid, "title": entry.title, "link": entry.link,
-                    "pubDate": entry.published, "category": category, "filename": filename,
+                    "guid": entry['guid'], "title": entry['title'], "link": entry['link'],
+                    "pubDate": entry['pubDate'], "category": category, "filename": filename,
                     "updated_date": datetime.now().strftime('%Y-%m-%d %H:%M:%S')
                 })
 

--- a/tests/test_fetch_feed.py
+++ b/tests/test_fetch_feed.py
@@ -1,0 +1,59 @@
+import unittest
+from types import SimpleNamespace
+
+from scripts import fetch_feed
+
+
+class FakeEntry(dict):
+    def __getattr__(self, item):
+        return self[item]
+
+
+class FetchFeedFallbackTests(unittest.TestCase):
+    def test_uses_primary_when_available(self):
+        primary_entries = [
+            FakeEntry(guid='g1', title='Policy A', link='https://example/a', published='Mon, 01 Jan 2024 10:00:00 GMT', category='Policy')
+        ]
+
+        def parser(url):
+            if url == fetch_feed.RSS_URL:
+                return SimpleNamespace(bozo=False, entries=primary_entries)
+            self.fail('Fallback feeds should not be called when primary succeeds')
+
+        entries, source = fetch_feed.fetch_entries_with_fallback(parser=parser)
+        self.assertEqual(source, 'primary')
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]['guid'], 'g1')
+
+    def test_falls_back_and_deduplicates_by_guid(self):
+        def parser(url):
+            if url == fetch_feed.RSS_URL:
+                return SimpleNamespace(bozo=True, bozo_exception=Exception('broken'), entries=[])
+            if 'type=79' in url:
+                return SimpleNamespace(bozo=False, entries=[
+                    FakeEntry(guid='g1', title='Old', link='https://example/old', published='Mon, 01 Jan 2024 10:00:00 GMT', category='Framework')
+                ])
+            if 'type=27' in url:
+                return SimpleNamespace(bozo=False, entries=[
+                    FakeEntry(guid='g1', title='New', link='https://example/new', published='Tue, 02 Jan 2024 10:00:00 GMT', category='Policy'),
+                    FakeEntry(guid='g2', title='Policy B', link='https://example/b', published='Wed, 03 Jan 2024 10:00:00 GMT', category='Policy'),
+                ])
+            return SimpleNamespace(bozo=False, entries=[])
+
+        entries, source = fetch_feed.fetch_entries_with_fallback(parser=parser)
+        self.assertEqual(source, 'fallback')
+        self.assertEqual([entry['guid'] for entry in entries], ['g2', 'g1'])
+        guid1 = next(e for e in entries if e['guid'] == 'g1')
+        self.assertEqual(guid1['title'], 'New')
+
+    def test_returns_empty_when_all_sources_fail(self):
+        def parser(_):
+            return SimpleNamespace(bozo=True, bozo_exception=Exception('unavailable'), entries=[])
+
+        entries, source = fetch_feed.fetch_entries_with_fallback(parser=parser)
+        self.assertEqual(source, 'fallback')
+        self.assertEqual(entries, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The main "latest changes" RSS feed (`feed=2`) is unreliable and was causing missed policy updates, so a resilient ingestion strategy is needed to continue detecting document changes. 
- The instrument-specific feeds (`feed=1&type=...`) remain available and contain the same policy documents, making them a low-risk source to reconstruct recent changes.

### Description
- Added `fetch_entries_with_fallback()` to `scripts/fetch_feed.py` which first tries the primary feed (`RSS_URL`) and, if malformed or empty, aggregates the five instrument-specific feeds listed in `FALLBACK_RSS_URLS`.
- Introduced `normalize_entry()` and `parse_pub_date()` helpers to produce a stable entry shape and comparable publication dates, and implemented GUID-level deduplication that keeps the most recent entry per GUID.
- Updated `main()` in `scripts/fetch_feed.py` to consume normalized entries from either source and continue the existing flow of downloading XML and updating `data/new_items.csv` and `data/items.csv`.
- Documented the fallback behavior in `README.md` and added unit tests under `tests/test_fetch_feed.py` to cover primary-path, fallback aggregation/deduplication, and total failure scenarios.

### Testing
- Ran unit tests with `PYTHONDONTWRITEBYTECODE=1 python -m unittest -v tests/test_fetch_feed.py`, which executed 3 tests and all passed (validates primary preference, fallback deduplication by GUID, and empty result on total failure). 
- Performed a quick smoke test with `from scripts.fetch_feed import fetch_entries_with_fallback` to exercise live endpoints; the script printed fallback warnings for the malformed primary feed and returned aggregated entries from fallback feeds (observed successful aggregation in the environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55df01ba4833193f90d75f444c690)