### PR TITLE
Require TBS-Policy-Hawk User-Agent for RSS feed requests

### DIFF
--- a/.github/workflows/init_xml_archives.yml
+++ b/.github/workflows/init_xml_archives.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   init-framework-xml:
     runs-on: ubuntu-latest
+    env:
+      TBS_POLICY_HAWK_USER_AGENT: "TBS-Policy-Hawk/1.0 (+https://github.com/TBS-Policy-Hawk)"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/policy_watch.yml
+++ b/.github/workflows/policy_watch.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   policy-hawk:
     runs-on: ubuntu-latest
+    env:
+      TBS_POLICY_HAWK_USER_AGENT: "TBS-Policy-Hawk/1.0 (+https://github.com/TBS-Policy-Hawk)"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/update_scd2.yml
+++ b/.github/workflows/update_scd2.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    env:
+      TBS_POLICY_HAWK_USER_AGENT: "TBS-Policy-Hawk/1.0 (+https://github.com/TBS-Policy-Hawk)"
     steps:
 
       - name: Checkout repo

--- a/PRD.md
+++ b/PRD.md
@@ -37,6 +37,7 @@ The current workflow detects items and creates issues, but it does not consisten
 
 ## Assumptions and Constraints
 - The RSS feed remains the primary change detection source.
+- RSS requests must include a custom `User-Agent` header (project agent) or requests may be blocked by upstream firewall rules.
 - The policy HTML page supports a simplified view via `section=HTML`.
 - The repository can store versioned policy content (SCD2 or similar).
 - GitHub Actions runtime is sufficient for screenshot capture and markdown conversion.
@@ -64,6 +65,7 @@ Refactor the project into a clear pipeline with these phases:
 ## Functional Requirements
 1. RSS and Change Detection
    - Parse RSS feed and persist items with a stable GUID.
+   - Send a project-specific `User-Agent` header on all RSS feed HTTP requests (both primary and fallback feeds, across scripts and workflows).
    - Detect updates vs new items with version tracking.
    - Avoid duplicates when a job re-runs.
 
@@ -94,6 +96,7 @@ Refactor the project into a clear pipeline with these phases:
 
 ## Non-Functional Requirements
 - Reliability: workflows should not fail on transient network errors.
+- Network compatibility: all RSS feed requests must set `User-Agent: TBS-Policy-Hawk/1.0 (+https://github.com/TBS-Policy-Hawk)`.
 - Performance: end-to-end enrichment should finish within 15 minutes.
 - Cost: stay within GitHub Actions free-tier constraints.
 - Security: do not leak tokens; store secrets in GitHub Actions secrets (Gemini API key).

--- a/scripts/fetch_feed.py
+++ b/scripts/fetch_feed.py
@@ -9,6 +9,7 @@ from email.utils import parsedate_to_datetime
 
 # --- Configuration ---
 RSS_URL = "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=2&count=100"
+USER_AGENT = os.getenv("TBS_POLICY_HAWK_USER_AGENT", "TBS-Policy-Hawk/1.0 (+https://github.com/TBS-Policy-Hawk)")
 FALLBACK_RSS_URLS = [
     "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=1&type=79",
     "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=1&type=27",
@@ -58,7 +59,13 @@ def normalize_entry(entry):
 
 def fetch_entries_with_fallback(parser=feedparser.parse):
     """Fetch entries from primary feed; use instrument feeds if main feed is unavailable."""
-    primary_feed = parser(RSS_URL)
+    def parse_feed(url):
+        try:
+            return parser(url, request_headers={"User-Agent": USER_AGENT})
+        except TypeError:
+            return parser(url)
+
+    primary_feed = parse_feed(RSS_URL)
     primary_entries = getattr(primary_feed, 'entries', [])
 
     if not getattr(primary_feed, 'bozo', False) and primary_entries:
@@ -71,7 +78,7 @@ def fetch_entries_with_fallback(parser=feedparser.parse):
 
     deduped_entries = {}
     for feed_url in FALLBACK_RSS_URLS:
-        fallback_feed = parser(feed_url)
+        fallback_feed = parse_feed(feed_url)
         if getattr(fallback_feed, 'bozo', False):
             print(f"Warning: fallback feed parse issue for {feed_url}: {fallback_feed.bozo_exception}")
             continue

--- a/scripts/init_framework_xml_archive.py
+++ b/scripts/init_framework_xml_archive.py
@@ -6,6 +6,8 @@ import requests
 import feedparser
 import xml.dom.minidom
 
+USER_AGENT = os.getenv("TBS_POLICY_HAWK_USER_AGENT", "TBS-Policy-Hawk/1.0 (+https://github.com/TBS-Policy-Hawk)")
+
 # Feeds and corresponding target directories
 feeds = {
     "Framework": "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=1&type=79",
@@ -25,7 +27,10 @@ for dir_name, feed_url in feeds.items():
     print(f"Processing {dir_name} feed...")
 
     # Parse feed
-    feed = feedparser.parse(feed_url)
+    try:
+        feed = feedparser.parse(feed_url, request_headers={"User-Agent": USER_AGENT})
+    except TypeError:
+        feed = feedparser.parse(feed_url)
 
     for entry in feed.entries:
         # Use HTTPS and add &section=xml

--- a/scripts/update_scd2.py
+++ b/scripts/update_scd2.py
@@ -17,6 +17,7 @@ FEEDS = {
     "en": "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=2&count=300",
     "fr": "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-fra.aspx?feed=2&count=300",
 }
+USER_AGENT = os.getenv("TBS_POLICY_HAWK_USER_AGENT", "TBS-Policy-Hawk/1.0 (+https://github.com/TBS-Policy-Hawk)")
 
 FALLBACK_FEEDS = {
     "en": [
@@ -60,7 +61,10 @@ def fetch_and_union():
         }
 
     def parse_feedparser(url, lang):
-        parsed = feedparser.parse(url)
+        try:
+            parsed = feedparser.parse(url, request_headers={"User-Agent": USER_AGENT})
+        except TypeError:
+            parsed = feedparser.parse(url)
         if getattr(parsed, "bozo", False) or not getattr(parsed, "entries", []):
             return None
         rows = [normalize_entry(entry, lang) for entry in parsed.entries]
@@ -88,7 +92,7 @@ def fetch_and_union():
         return pd.DataFrame(deduped.values())
 
     def parse_rss(url, lang):
-        resp = requests.get(url, timeout=60)
+        resp = requests.get(url, timeout=60, headers={"User-Agent": USER_AGENT})
         resp.raise_for_status()
         root = ET.fromstring(resp.content)
         rows = []


### PR DESCRIPTION
### Motivation
- Upstream firewall blocks RSS requests that do not set a `User-Agent`, so feed fetches can be rejected silently. 
- Use a project-specific agent string to identify the tool to the TBS feed endpoint and avoid being blocked. 
- Update the product requirements to document this operational constraint so workflows and scripts remain compatible with the feed provider.

### Description
- Introduced a configurable `TBS_POLICY_HAWK_USER_AGENT` (default `TBS-Policy-Hawk/1.0 (+https://github.com/TBS-Policy-Hawk)`) and used it when parsing RSS feeds in `scripts/fetch_feed.py` via a `parse_feed` wrapper that calls `feedparser.parse(..., request_headers={"User-Agent": ...})` with a safe fallback for older `feedparser` signatures. 
- Applied the same `User-Agent` handling to `scripts/update_scd2.py` (both `feedparser.parse(...)` and `requests.get(...)` fallback) and to `scripts/init_framework_xml_archive.py` (feed parsing). 
- Exposed the `TBS_POLICY_HAWK_USER_AGENT` environment variable in RSS-related GitHub Actions workflows: `.github/workflows/policy_watch.yml`, `.github/workflows/update_scd2.yml`, and `.github/workflows/init_xml_archives.yml`. 
- Updated `PRD.md` to document the `User-Agent` requirement in the assumptions, functional requirements, and non-functional requirements sections.

### Testing
- Ran the unit tests in `tests/test_fetch_feed.py` with `PYTHONPATH=.` and they passed: `3 passed`. 
- An initial test run without `PYTHONPATH` failed to import the `scripts` package due to the test environment, which was resolved by running `PYTHONPATH=. pytest -q tests/test_fetch_feed.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc24d58508331bbf66340c6d17fe5)