### PR TITLE
Add modifications-table fallback for feed ingestion, normalize categories/dates, and add tests

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -38,6 +38,8 @@ The current workflow detects items and creates issues, but it does not consisten
 ## Assumptions and Constraints
 - The RSS feed remains the primary change detection source.
 - RSS requests must include a custom `User-Agent` header (project agent) or requests may be blocked by upstream firewall rules.
+- If RSS endpoints fail, workflows must fall back to scraping the TBS modifications table (`modifications-eng.aspx` / `modifications-fra.aspx`) so change detection can continue.
+- RSS endpoint URLs must be validated and must not include malformed trailing punctuation (for example, `type=83:` is invalid; `type=83` is valid).
 - The policy HTML page supports a simplified view via `section=HTML`.
 - The repository can store versioned policy content (SCD2 or similar).
 - GitHub Actions runtime is sufficient for screenshot capture and markdown conversion.
@@ -66,6 +68,8 @@ Refactor the project into a clear pipeline with these phases:
 1. RSS and Change Detection
    - Parse RSS feed and persist items with a stable GUID.
    - Send a project-specific `User-Agent` header on all RSS feed HTTP requests (both primary and fallback feeds, across scripts and workflows).
+   - When primary and instrument RSS feeds are unavailable, scrape `table#results-table` from TBS modifications pages and map rows into the same canonical item fields (`guid`, `title`, `link`, `pubDate`, and descriptive text).
+   - Keep RSS URL configuration sanitized across scripts/workflows (no trailing colon after query parameter values).
    - Detect updates vs new items with version tracking.
    - Avoid duplicates when a job re-runs.
 

--- a/scripts/fetch_feed.py
+++ b/scripts/fetch_feed.py
@@ -17,10 +17,24 @@ FALLBACK_RSS_URLS = [
     "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=1&type=36",
     "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=1&type=83",
 ]
+MODIFICATIONS_TABLE_URLS = [
+    "https://www.tbs-sct.canada.ca/pol/modifications-eng.aspx",
+    "https://www.tbs-sct.canada.ca/pol/modifications-fra.aspx",
+]
 DATA_DIR = "data"
 ITEMS_CSV_PATH = os.path.join(DATA_DIR, "items.csv")
 NEW_ITEMS_CSV_PATH = os.path.join(DATA_DIR, "new_items.csv")
 CSV_HEADERS = ["guid", "title", "link", "pubDate", "category", "filename", "updated_date"]
+FRENCH_CATEGORY_MAP = {
+    "Politique": "Policy",
+    "Directive": "Directive",
+    "Norme": "Standard",
+    "Ligne directrice": "Guideline",
+    "Lignes directrices": "Guideline",
+    "Guide": "Guide",
+    "Cadre stratégique": "Framework",
+    "Cadre": "Framework",
+}
 
 # --- Helper Functions ---
 
@@ -55,6 +69,73 @@ def normalize_entry(entry):
         "pubDate": entry.get('published', ''),
         "category": entry.get('category', 'Uncategorized'),
     }
+
+
+def normalize_category(label):
+    """Normalize category labels to repository folder names where possible."""
+    if not label:
+        return "Uncategorized"
+    normalized = label.strip()
+    return FRENCH_CATEGORY_MAP.get(normalized, normalized)
+
+
+def format_iso_date_for_pub_date(date_text):
+    """Convert YYYY-MM-DD strings into RSS-like date text for compatibility."""
+    try:
+        dt = datetime.strptime(date_text.strip(), "%Y-%m-%d")
+    except (TypeError, ValueError, AttributeError):
+        return ""
+    return dt.strftime("%a, %d %b %Y 00:00:00 GMT")
+
+
+def fetch_entries_from_modifications_table(getter=requests.get):
+    """Scrape the modifications table as a last-resort source of updates."""
+    for page_url in MODIFICATIONS_TABLE_URLS:
+        try:
+            response = getter(page_url, timeout=30, headers={"User-Agent": USER_AGENT})
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            print(f"Warning: unable to retrieve modifications table ({page_url}): {exc}")
+            continue
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        table = soup.find("table", id="results-table")
+        if not table:
+            print(f"Warning: modifications table not found on {page_url}")
+            continue
+
+        entries = []
+        rows = table.select("tbody tr")
+        for row in rows:
+            title_link = row.select_one("td h2 a")
+            date_cell = row.select_one("td:nth-of-type(2)")
+            metadata = row.select_one("td p.text-muted")
+
+            if not title_link or not date_cell:
+                continue
+
+            title = title_link.get_text(strip=True)
+            link = requests.compat.urljoin(page_url, title_link.get("href", "").strip())
+            date_text = date_cell.get_text(strip=True)
+            category_text = "Uncategorized"
+            if metadata:
+                category_text = metadata.get_text(" ", strip=True).split("|", 1)[0].strip()
+
+            doc_id_match = re.search(r"id=(\d+)", link)
+            guid = doc_id_match.group(1) if doc_id_match else link
+
+            entries.append({
+                "guid": guid,
+                "title": title,
+                "link": link,
+                "pubDate": format_iso_date_for_pub_date(date_text),
+                "category": normalize_category(category_text),
+            })
+
+        if entries:
+            return entries
+
+    return []
 
 
 def fetch_entries_with_fallback(parser=feedparser.parse):
@@ -96,7 +177,19 @@ def fetch_entries_with_fallback(parser=feedparser.parse):
         key=lambda e: parse_pub_date(e['pubDate']),
         reverse=True,
     )
-    return sorted_entries, "fallback"
+    if sorted_entries:
+        return sorted_entries, "fallback"
+
+    table_entries = fetch_entries_from_modifications_table()
+    if table_entries:
+        sorted_table_entries = sorted(
+            table_entries,
+            key=lambda e: parse_pub_date(e['pubDate']),
+            reverse=True,
+        )
+        return sorted_table_entries, "modifications-table"
+
+    return [], "fallback"
 
 def get_existing_guids(filepath):
     """Reads the existing CSV file and returns a set of GUIDs."""
@@ -135,12 +228,15 @@ def download_policy_xml(url, category, title, pub_date):
             sanitized_title = sanitize_filename(title.replace(' ', '_'))
             base_filename = f"{sanitized_title}_{doc_id}"
 
-        try:
-            dt_object = datetime.strptime(pub_date, '%a, %d %b %Y %H:%M:%S %Z')
-            date_str = dt_object.strftime('%Y-%m-%d')
-        except ValueError:
-            date_str = datetime.now().strftime('%Y-%m-%d')
-            print(f"Warning: Could not parse date '{pub_date}'. Using current date.")
+        parsed_date = parse_pub_date(pub_date)
+        if parsed_date != datetime.min:
+            date_str = parsed_date.strftime('%Y-%m-%d')
+        else:
+            try:
+                date_str = datetime.strptime(pub_date, '%Y-%m-%d').strftime('%Y-%m-%d')
+            except (TypeError, ValueError):
+                date_str = datetime.now().strftime('%Y-%m-%d')
+                print(f"Warning: Could not parse date '{pub_date}'. Using current date.")
 
         filename = f"{base_filename}_{date_str}.xml"
         

--- a/scripts/update_scd2.py
+++ b/scripts/update_scd2.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 import os
+import re
 import requests
 import xml.etree.ElementTree as ET
 import hashlib
 import pandas as pd
 import feedparser
+from bs4 import BeautifulSoup
 from datetime import datetime, timezone
 from pathlib import Path
 import subprocess
@@ -34,6 +36,10 @@ FALLBACK_FEEDS = {
         "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-fra.aspx?feed=1&type=36",
         "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-fra.aspx?feed=1&type=83",
     ],
+}
+MODIFICATIONS_TABLE_URLS = {
+    "en": "https://www.tbs-sct.canada.ca/pol/modifications-eng.aspx",
+    "fr": "https://www.tbs-sct.canada.ca/pol/modifications-fra.aspx",
 }
 
 SCD2_PATH = REPO_ROOT / "data" / "tbs_policy_feed_scd2.csv"
@@ -110,6 +116,41 @@ def fetch_and_union():
             })
         return pd.DataFrame(rows)
 
+    def parse_modifications_table(lang):
+        url = MODIFICATIONS_TABLE_URLS[lang]
+        response = requests.get(url, timeout=60, headers={"User-Agent": USER_AGENT})
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, "html.parser")
+        table = soup.find("table", id="results-table")
+        if not table:
+            return pd.DataFrame()
+
+        rows = []
+        for tr in table.select("tbody tr"):
+            title_link = tr.select_one("td h2 a")
+            date_cell = tr.select_one("td:nth-of-type(2)")
+            summary_cell = tr.select_one("td p.mrgn-bttm-0")
+            if not title_link or not date_cell:
+                continue
+
+            href = (title_link.get("href") or "").strip()
+            link = requests.compat.urljoin(url, href)
+            date_text = date_cell.get_text(strip=True)
+            pub_date = pd.to_datetime(date_text, errors="coerce")
+            pub_date_text = "" if pd.isna(pub_date) else pub_date.strftime("%a, %d %b %Y 00:00:00 GMT")
+            guid_match = re.search(r"id=(\d+)", link)
+            guid = guid_match.group(1) if guid_match else link
+
+            rows.append({
+                "guid": guid,
+                f"title_{lang}": title_link.get_text(strip=True),
+                f"link_{lang}": link,
+                f"description_{lang}": (summary_cell.get_text(strip=True) if summary_cell else ""),
+                f"pubDate_{lang}": pub_date_text,
+            })
+
+        return pd.DataFrame(rows)
+
     def load_lang_feed(lang):
         parsed = parse_feedparser(FEEDS[lang], lang)
         if parsed is not None and not parsed.empty:
@@ -117,10 +158,16 @@ def fetch_and_union():
 
         print(f"Primary {lang} feed unavailable. Falling back to instrument feeds.")
         fallback = parse_fallback_feeds(lang)
-        if fallback.empty:
-            # Keep the original parser as a last-resort attempt to preserve behaviour.
-            return parse_rss(FEEDS[lang], lang)
-        return fallback
+        if not fallback.empty:
+            return fallback
+
+        print(f"Fallback instrument feeds unavailable for {lang}. Falling back to modifications table.")
+        table_fallback = parse_modifications_table(lang)
+        if not table_fallback.empty:
+            return table_fallback
+
+        # Keep the original parser as a final last-resort attempt to preserve behaviour.
+        return parse_rss(FEEDS[lang], lang)
 
     en = load_lang_feed("en")
     fr = load_lang_feed("fr")

--- a/tests/test_fetch_feed.py
+++ b/tests/test_fetch_feed.py
@@ -1,5 +1,6 @@
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from scripts import fetch_feed
 
@@ -46,13 +47,70 @@ class FetchFeedFallbackTests(unittest.TestCase):
         guid1 = next(e for e in entries if e['guid'] == 'g1')
         self.assertEqual(guid1['title'], 'New')
 
-    def test_returns_empty_when_all_sources_fail(self):
+    @patch('scripts.fetch_feed.fetch_entries_from_modifications_table')
+    def test_uses_modifications_table_when_all_rss_sources_fail(self, mock_table):
+        mock_table.return_value = [
+            {'guid': 'g3', 'title': 'Policy C', 'link': 'https://example/c', 'pubDate': '2026-03-12', 'category': 'Policy'}
+        ]
+
+        def parser(_):
+            return SimpleNamespace(bozo=True, bozo_exception=Exception('unavailable'), entries=[])
+
+        entries, source = fetch_feed.fetch_entries_with_fallback(parser=parser)
+        self.assertEqual(source, 'modifications-table')
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]['guid'], 'g3')
+
+    @patch('scripts.fetch_feed.fetch_entries_from_modifications_table')
+    def test_returns_empty_when_all_sources_fail(self, mock_table):
+        mock_table.return_value = []
+
         def parser(_):
             return SimpleNamespace(bozo=True, bozo_exception=Exception('unavailable'), entries=[])
 
         entries, source = fetch_feed.fetch_entries_with_fallback(parser=parser)
         self.assertEqual(source, 'fallback')
         self.assertEqual(entries, [])
+
+
+class ModificationsTableParsingTests(unittest.TestCase):
+    def test_extracts_rows_and_normalizes_fields(self):
+        html = """
+        <table id="results-table">
+          <tbody>
+            <tr>
+              <td>
+                <h2><a href="doc-eng.aspx?id=32728">Making Communications Products and Activities Accessible, Guidelines on</a></h2>
+                <p class="text-muted">Guidelines | <a href="#">Communications and Federal Identity</a></p>
+              </td>
+              <td>2026-03-12</td>
+            </tr>
+          </tbody>
+        </table>
+        """
+
+        class FakeResponse:
+            def __init__(self, text):
+                self.text = text
+
+            def raise_for_status(self):
+                return None
+
+        def getter(url, timeout, headers):
+            return FakeResponse(html)
+
+        entries = fetch_feed.fetch_entries_from_modifications_table(getter=getter)
+        self.assertEqual(len(entries), 1)
+        row = entries[0]
+        self.assertEqual(row['guid'], '32728')
+        self.assertEqual(row['category'], 'Guidelines')
+        self.assertEqual(row['pubDate'], 'Thu, 12 Mar 2026 00:00:00 GMT')
+        self.assertEqual(row['link'], 'https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=32728')
+
+    def test_normalizes_french_categories(self):
+        self.assertEqual(fetch_feed.normalize_category('Politique'), 'Policy')
+        self.assertEqual(fetch_feed.normalize_category('Directive'), 'Directive')
+        self.assertEqual(fetch_feed.normalize_category('Cadre stratégique'), 'Framework')
 
 
 if __name__ == '__main__':

--- a/tests/test_update_scd2.py
+++ b/tests/test_update_scd2.py
@@ -1,0 +1,71 @@
+import unittest
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import patch
+from pathlib import Path
+
+from scripts import update_scd2
+
+
+class UpdateSCD2FallbackTests(unittest.TestCase):
+    @patch('scripts.update_scd2.requests.get')
+    @patch('scripts.update_scd2.feedparser.parse')
+    def test_uses_modifications_table_when_rss_unavailable(self, mock_parse, mock_get):
+        # Primary and instrument feeds unavailable for both languages.
+        mock_parse.return_value = SimpleNamespace(bozo=True, entries=[])
+
+        html_en = """
+        <table id='results-table'><tbody>
+          <tr>
+            <td>
+              <h2><a href='doc-eng.aspx?id=32728'>Making Communications Products and Activities Accessible, Guidelines on</a></h2>
+              <p class='mrgn-bttm-0'>English summary text.</p>
+            </td>
+            <td>2026-03-12</td>
+          </tr>
+        </tbody></table>
+        """
+        html_fr = """
+        <table id='results-table'><tbody>
+          <tr>
+            <td>
+              <h2><a href='doc-fra.aspx?id=32728'>Rendre les produits et activités de communication accessibles, Lignes directrices sur</a></h2>
+              <p class='mrgn-bttm-0'>Résumé français.</p>
+            </td>
+            <td>2026-03-12</td>
+          </tr>
+        </tbody></table>
+        """
+
+        class FakeResponse:
+            def __init__(self, text):
+                self.text = text
+                self.content = text.encode('utf-8')
+
+            def raise_for_status(self):
+                return None
+
+        def fake_get(url, timeout=60, headers=None):
+            if 'modifications-eng.aspx' in url:
+                return FakeResponse(html_en)
+            if 'modifications-fra.aspx' in url:
+                return FakeResponse(html_fr)
+            # Final parse_rss fallback should not be hit in this test.
+            raise AssertionError(f'unexpected URL requested: {url}')
+
+        mock_get.side_effect = fake_get
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(update_scd2, 'TMP_SNAPSHOT', Path(tmpdir) / 'snapshot.csv'):
+                df = update_scd2.fetch_and_union()
+        self.assertEqual(len(df), 1)
+        row = df.iloc[0]
+        self.assertEqual(row['guid'], '32728')
+        self.assertIn('doc-eng.aspx?id=32728', row['link_en'])
+        self.assertIn('doc-fra.aspx?id=32728', row['link_fr'])
+        self.assertEqual(row['description_en'], 'English summary text.')
+        self.assertEqual(row['description_fr'], 'Résumé français.')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure change detection continues when RSS endpoints are unavailable by falling back to scraping the TBS `modifications` pages. 
- Normalize category labels (French→English) and make publication date parsing more robust for data consistency. 
- Enforce using a project `User-Agent` across requests and validate/sanitize feed URLs to avoid malformed query values. 

### Description
- Updated `PRD.md` to document the modifications-table fallback and RSS URL validation requirements. 
- Extended `scripts/fetch_feed.py` to add `MODIFICATIONS_TABLE_URLS`, a `FRENCH_CATEGORY_MAP`, `normalize_category`, `format_iso_date_for_pub_date`, and `fetch_entries_from_modifications_table` that scrapes `table#results-table` as a last-resort source; integrated this into `fetch_entries_with_fallback` and improved `download_policy_xml` date handling. 
- Extended `scripts/update_scd2.py` to add `MODIFICATIONS_TABLE_URLS`, import `BeautifulSoup`, implement `parse_modifications_table`, and use it when primary and fallback RSS feeds are unavailable. 
- Added and updated unit tests: `tests/test_fetch_feed.py` now includes tests for using the modifications table and category normalization, and a new `tests/test_update_scd2.py` verifies the modifications-table fallback for SCD2 feed union. 

### Testing
- Ran the unit tests in `tests/test_fetch_feed.py` using `python -m unittest` and the new tests for the modifications-table fallback passed. 
- Ran the added `tests/test_update_scd2.py` with `python -m unittest` and it passed, confirming the SCD2 fallback behavior. 
- All modified and new automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de18ff24d4833195d39c36a8ea7e38)