### PR TITLE
Add PolicyEvolution entry for issue #261 (Directive on Digital Talent)

### DIFF
--- a/PolicyEvolution2026-27Q2.md
+++ b/PolicyEvolution2026-27Q2.md
@@ -1,0 +1,50 @@
+# Policy Evolution 2026-27 Q2
+
+**Period covered:** 2026-07-01 to 2026-09-30  
+**Source:** Auto-analysis comments added to TBS-Policy-Hawk issues.
+
+This file compiles policy-change analysis comments for updates detected during the quarter. Entries are organized chronologically by the effective/update date in the issue GUID.
+
+---
+
+## 2026-07-06 — Digital Talent, Directive on
+
+**Issue:** [#261](https://github.com/PatLittle/TBS-Policy-Hawk/issues/261)  
+**Document ID:** 32749  
+**Category:** Directive  
+**GUID:** `32749_2026-07-06`
+
+### Policy change analysis
+
+Compared the current captured version for `32749_2026-07-06` with the closest prior repository copy:
+
+- New/current capture: `data/Directive/32749_2026-07-06/20260707T152541Z.md`
+- Prior version used for comparison: `data/Directive/Digital Talent Directive on_2025-08-31.xml`
+
+#### Summary
+
+This update is a targeted procedural amendment to the mandatory procedures for digital talent sourcing. The main substantive change removes explicit reliance on the GC Digital Talent platform from two TBS-OCIO interaction points and instead states the requirement in platform-neutral terms.
+
+#### Substantive changes identified
+
+| Section | Prior version | New/current version | Interpretation |
+|---|---|---|---|
+| **A.2.5.1.1** | Required managers/delegated authorities to check TBS-OCIO-led centralized talent recruitment and talent management pools **using the GC Digital Talent platform** before launching department-specific recruitment or initiating a digital services contract. | Requires checking TBS-OCIO-led centralized talent recruitment and talent management pools, but no longer names the GC Digital Talent platform. | The obligation to verify available centralized talent remains, but the channel is now technology-neutral and no longer tied to a named platform. |
+| **A.2.5.4.2** | Directed managers/delegated authorities to follow instructions on the GC Digital Talent Platform to complete and submit the Digital Services Contracting Questionnaire. | Requires completion and submission of the Digital Services Contracting Questionnaire directly to TBS-OCIO when qualifying procurements are submitted to contracting authorities, and links to the questionnaire document. | The questionnaire requirement remains, but the process is reframed around direct submission to TBS-OCIO rather than platform-based instructions. |
+| **A.2.5.4.3** | Required confirmation with TBS-OCIO **using the GC Digital Talent Platform** that no available pre-qualified talent in a TBS-OCIO-coordinated pool could meet the need before relying on a talent shortage as the rationale for contracting out. | Requires confirmation with TBS-OCIO that no available pre-qualified talent in a TBS-OCIO-coordinated pool could meet the need in the timeframe provided, without specifying the platform. | The pre-contracting confirmation obligation remains, but the specified confirmation mechanism has been removed. |
+
+#### Practical effect
+
+1. **Platform-neutral compliance:** Departments still need to check centralized digital talent pools and engage TBS-OCIO, but the directive no longer makes the GC Digital Talent platform the explicit route for those steps.
+2. **Procurement questionnaire retained:** The Digital Services Contracting Questionnaire remains mandatory for contracts, amendments and task authorizations that exceed $40,000 and align with the cited procurement procedures.
+3. **Contracting-out rationale still constrained:** Managers and delegated authorities must still confirm with TBS-OCIO that suitable pre-qualified talent is unavailable before citing talent shortage as the primary reason to contract out.
+
+#### Non-substantive changes
+
+Most remaining differences appear to be formatting, link rendering, punctuation spacing, and conversion differences between the prior HTML/XML capture and the current markdown capture.
+
+#### Watch item
+
+Because the named GC Digital Talent platform references were removed rather than replaced with a specific alternate workflow, departments may need operational guidance from TBS-OCIO on the current channel for pool checks, questionnaire submission, and pre-qualified talent confirmation.
+
+---


### PR DESCRIPTION
### Motivation
- Record the auto-analysis of policy-update issue `#261` (Directive on Digital Talent) in the fiscal-quarter report so repository policy-evolution tracking reflects the July 6, 2026 capture and its comparison to the closest prior copy.

### Description
- Add `PolicyEvolution2026-27Q2.md` containing the analysis for `32749_2026-07-06`, including the current capture path `data/Directive/32749_2026-07-06/20260707T152541Z.md`, the prior comparison file `data/Directive/Digital Talent Directive on_2025-08-31.xml`, a summary of substantive changes (removal of explicit references to the GC Digital Talent platform), non-substantive notes, and a watch item.
- Commit the new file to the current branch with the message `Analyze policy update issue 261`.

### Testing
- Ran the repository validation script `python3 - <<'PY' ... PY` which asserted the presence of the issue GUID and comparison paths in `PolicyEvolution2026-27Q2.md`, and the assertion passed.
- Verified the file contents with `nl`/`sed` inspection and committed the file successfully (`git commit` completed with the new file recorded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d1b31092c8331a395461a754e1709)