### PR TITLE
Add hierarchy and glossary policy watch

### DIFF
--- a/scripts/create_issues_with_screenshots.py
+++ b/scripts/create_issues_with_screenshots.py
@@ -1,13 +1,13 @@
 import os
 import csv
 import json
-from github import Github
-from playwright.sync_api import sync_playwright
+import re
 
 # --- Configuration ---
 DATA_DIR = "data"
 NEW_ITEMS_CSV_PATH = os.path.join(DATA_DIR, "new_items.csv")
 ISSUE_MAP_JSON_PATH = os.path.join(DATA_DIR, "issue_map.json")
+GLOSSARY_CHANGES_JSON_PATH = os.path.join(DATA_DIR, "glossary_changes.json")
 SCREENSHOTS_DIR = "screenshots"
 REPO_NAME = os.environ.get("GITHUB_REPOSITORY")
 
@@ -33,8 +33,135 @@ def save_issue_map(issue_map):
     with open(ISSUE_MAP_JSON_PATH, 'w', encoding='utf-8') as f:
         json.dump(issue_map, f, indent=2)
 
+
+def load_glossary_changes():
+    if not os.path.exists(GLOSSARY_CHANGES_JSON_PATH):
+        return {}
+    with open(GLOSSARY_CHANGES_JSON_PATH, 'r', encoding='utf-8') as f:
+        try:
+            payload = json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return payload.get("changes_by_source", {})
+
+
+def safe_filename(value):
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_") or "screenshot"
+
+
+def document_id_for_row(row):
+    for key in ("source_id", "related_guid", "guid"):
+        match = re.search(r"(\d+)", row.get(key, ""))
+        if match:
+            return match.group(1)
+    return ""
+
+
+def summarize_terms(items, label):
+    if not items:
+        return ""
+    lines = [f"**{label}:**"]
+    for item in items[:10]:
+        term_en = item.get("term_en") or "n/a"
+        term_fr = item.get("term_fr") or "n/a"
+        fields = item.get("fields")
+        suffix = f" ({', '.join(fields)})" if fields else ""
+        lines.append(f"- `{term_en}` / `{term_fr}`{suffix}")
+    if len(items) > 10:
+        lines.append(f"- ...and {len(items) - 10} more.")
+    return "\n".join(lines)
+
+
+def glossary_change_section(source_id, glossary_changes):
+    payload = glossary_changes.get(source_id)
+    if not payload:
+        return ""
+
+    added = payload.get("added", [])
+    removed = payload.get("removed", [])
+    changed = payload.get("changed", [])
+    total = len(added) + len(removed) + len(changed)
+    source_title = payload.get("source_en") or payload.get("source_fr") or source_id
+    parts = [
+        "### Glossary changes",
+        "",
+        f"{total} glossary term change(s) were detected for `{source_id}` ({source_title}).",
+        "",
+    ]
+    for section in [
+        summarize_terms(added, "Added terms"),
+        summarize_terms(removed, "Removed terms"),
+        summarize_terms(changed, "Changed terms"),
+    ]:
+        if section:
+            parts.extend([section, ""])
+    return "\n".join(parts).rstrip()
+
+
+def issue_body_for_row(row, screenshot_success, screenshot_url, glossary_changes):
+    change_type = row.get("change_type") or "policy_update"
+    doc_id = document_id_for_row(row)
+    glossary_section = glossary_change_section(doc_id, glossary_changes)
+    screenshot_section = (
+        f"### Screenshot\n![Screenshot of policy page]({screenshot_url})"
+        if screenshot_success else
+        "*Failed to capture screenshot.*"
+    )
+
+    if change_type == "hierarchy_added":
+        body = (
+            "A policy instrument has been added to the TBS policy hierarchy tree.\n\n"
+            f"**Title:** {row['title']}\n**Link:** {row['link']}\n"
+            f"**Category:** {row['category']}\n**GUID:** {row['guid']}\n"
+            f"**Hierarchy document ID:** {doc_id}\n\n"
+            f"{row.get('change_summary', '')}\n\n"
+            f"{screenshot_section}"
+        )
+    elif change_type == "hierarchy_removed":
+        body = (
+            "A policy instrument has been removed from the TBS policy hierarchy tree.\n\n"
+            f"**Title:** {row['title']}\n**Link:** {row['link']}\n"
+            f"**Category:** {row['category']}\n**GUID:** {row['guid']}\n"
+            f"**Hierarchy document ID:** {doc_id}\n\n"
+            f"{row.get('change_summary', '')}\n\n"
+            f"{screenshot_section}"
+        )
+    elif change_type == "glossary":
+        body = (
+            "Glossary terms changed for a tracked policy instrument, and no policy update issue was created for that source in this run.\n\n"
+            f"**Title:** {row['title']}\n**Link:** {row['link']}\n"
+            f"**Category:** {row['category']}\n**GUID:** {row['guid']}\n"
+            f"**Source document ID:** {doc_id}\n\n"
+            f"{glossary_section}\n\n"
+            f"{screenshot_section}"
+        )
+    else:
+        body = (
+            f"A new or updated policy document has been detected.\n\n"
+            f"**Title:** {row['title']}\n**Link:** {row['link']}\n"
+            f"**Category:** {row['category']}\n**GUID:** {row['guid']}\n\n"
+            f"{screenshot_section}"
+        )
+
+    if glossary_section and change_type not in {"glossary"}:
+        body = f"{body}\n\n{glossary_section}"
+    return body
+
+
+def create_issue_with_fallback(repo, title, body, labels):
+    labels = [label for label in labels if label]
+    try:
+        return repo.create_issue(title=title, body=body, labels=labels)
+    except Exception as exc:
+        if labels != ["policy-update"]:
+            print(f"Warning: issue creation with labels {labels} failed: {exc}. Retrying with policy-update only.")
+            return repo.create_issue(title=title, body=body, labels=["policy-update"])
+        raise
+
 def take_screenshot(url, filepath):
     """Takes a screenshot of a given URL with a Windows 11 user agent. On failure, retries with HTTPS."""
+    from playwright.sync_api import sync_playwright
+
     WINDOWS11_UA = (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     )
@@ -80,9 +207,12 @@ def main():
         print("No new items found (new_items.csv does not exist). Exiting.")
         return
 
+    from github import Github
+
     g = Github(github_token)
     repo = g.get_repo(REPO_NAME)
     issue_map = load_issue_map()
+    glossary_changes = load_glossary_changes()
     
     ensure_dir(SCREENSHOTS_DIR)
 
@@ -95,19 +225,26 @@ def main():
                 continue
 
             print(f"Creating issue for new item: {row['title']}")
-            screenshot_filename = f"{guid.replace('/', '_')}.png"
+            screenshot_filename = f"{safe_filename(guid)}.png"
             screenshot_filepath = os.path.join(SCREENSHOTS_DIR, screenshot_filename)
             screenshot_success = take_screenshot(row['link'], screenshot_filepath)
             
             screenshot_url = f"https://github.com/{REPO_NAME}/blob/main/{screenshot_filepath}?raw=true"
-            issue_body = (f"A new or updated policy document has been detected.\n\n"
-                          f"**Title:** {row['title']}\n**Link:** {row['link']}\n"
-                          f"**Category:** {row['category']}\n**GUID:** {guid}\n\n"
-                          f"### Screenshot\n"
-                          f"![Screenshot of policy page]({screenshot_url})" if screenshot_success else "*Failed to capture screenshot.*")
+            issue_body = issue_body_for_row(row, screenshot_success, screenshot_url, glossary_changes)
+            change_type = row.get("change_type") or "policy_update"
+            title_prefix = "Policy Update"
+            if change_type == "hierarchy_added":
+                title_prefix = "Policy Hierarchy Addition"
+            elif change_type == "hierarchy_removed":
+                title_prefix = "Policy Hierarchy Removal"
+            elif change_type == "glossary":
+                title_prefix = "Glossary Update"
 
             try:
-                issue = repo.create_issue(title=f"Policy Update: {row['title']}", body=issue_body, labels=[row['category'], "policy-update"])
+                labels = [row.get('category'), "policy-update"]
+                if change_type == "glossary":
+                    labels.append("glossary-update")
+                issue = create_issue_with_fallback(repo, f"{title_prefix}: {row['title']}", issue_body, labels)
                 print(f"Successfully created issue #{issue.number} for '{row['title']}'")
                 issue_map[guid] = issue.number
             except Exception as e:

--- a/scripts/fetch_feed.py
+++ b/scripts/fetch_feed.py
@@ -7,6 +7,39 @@ from bs4 import BeautifulSoup
 from datetime import datetime
 from email.utils import parsedate_to_datetime
 
+try:
+    from scripts.policy_sources import (
+        GLOSSARY_URLS,
+        HIERARCHY_URL,
+        build_glossary_change_payload,
+        compare_glossary_rows,
+        compare_hierarchy,
+        fetch_glossary_rows,
+        fetch_hierarchy_records,
+        read_glossary_csv,
+        read_hierarchy_csv,
+        write_glossary_csv,
+        write_glossary_markdown,
+        write_hierarchy_csv,
+        write_json,
+    )
+except ModuleNotFoundError:
+    from policy_sources import (
+        GLOSSARY_URLS,
+        HIERARCHY_URL,
+        build_glossary_change_payload,
+        compare_glossary_rows,
+        compare_hierarchy,
+        fetch_glossary_rows,
+        fetch_hierarchy_records,
+        read_glossary_csv,
+        read_hierarchy_csv,
+        write_glossary_csv,
+        write_glossary_markdown,
+        write_hierarchy_csv,
+        write_json,
+    )
+
 # --- Configuration ---
 RSS_URL = "https://www.tbs-sct.canada.ca/pol/rssfeeds-filsrss-eng.aspx?feed=2&count=100"
 USER_AGENT = os.getenv("TBS_POLICY_HAWK_USER_AGENT", "TBS-Policy-Hawk/1.0 (+https://github.com/TBS-Policy-Hawk)")
@@ -24,7 +57,17 @@ MODIFICATIONS_TABLE_URLS = [
 DATA_DIR = "data"
 ITEMS_CSV_PATH = os.path.join(DATA_DIR, "items.csv")
 NEW_ITEMS_CSV_PATH = os.path.join(DATA_DIR, "new_items.csv")
+HIERARCHY_CSV_PATH = os.path.join(DATA_DIR, "tbs_policy_hierarchy_full.csv")
+GLOSSARY_CSV_PATH = os.path.join(DATA_DIR, "policy_glossary.csv")
+GLOSSARY_MD_PATH = os.path.join(DATA_DIR, "policy_glossary.md")
+GLOSSARY_CHANGES_JSON_PATH = os.path.join(DATA_DIR, "glossary_changes.json")
 CSV_HEADERS = ["guid", "title", "link", "pubDate", "category", "filename", "updated_date"]
+NEW_ITEMS_CSV_HEADERS = CSV_HEADERS + [
+    "change_type",
+    "change_summary",
+    "related_guid",
+    "source_id",
+]
 FRENCH_CATEGORY_MAP = {
     "Politique": "Policy",
     "Directive": "Directive",
@@ -206,6 +249,26 @@ def get_existing_guids(filepath):
             guids.add(row['guid'])
     return guids
 
+
+def today_iso():
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def new_item_row(guid, title, link, pub_date, category, filename="", change_type="policy_update", change_summary="", related_guid="", source_id=""):
+    return {
+        "guid": guid,
+        "title": title,
+        "link": link,
+        "pubDate": pub_date,
+        "category": category,
+        "filename": filename,
+        "updated_date": datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        "change_type": change_type,
+        "change_summary": change_summary,
+        "related_guid": related_guid,
+        "source_id": source_id,
+    }
+
 def download_policy_xml(url, category, title, pub_date):
     """Downloads the policy HTML from a given URL and saves it to the correct category directory."""
     # Ensure the URL uses https and contains section=html
@@ -267,22 +330,107 @@ def main():
 
     entries, source = fetch_entries_with_fallback()
     if not entries:
-        print("Error: unable to fetch entries from both main and fallback RSS feeds.")
-        return
-    print(f"Using {source} feed source with {len(entries)} entries.")
+        print("Warning: unable to fetch entries from main, fallback RSS feeds, or modifications table. Continuing with hierarchy and glossary checks.")
+    else:
+        print(f"Using {source} feed source with {len(entries)} entries.")
 
     new_items = []
+    policy_issue_document_ids = set()
     for entry in entries:
         if entry['guid'] not in existing_guids:
             print(f"New item found: {entry['title']} ({entry['guid']})")
             category = entry['category']
             filename = download_policy_xml(entry['link'], category, entry['title'], entry['pubDate'])
             if filename:
-                new_items.append({
-                    "guid": entry['guid'], "title": entry['title'], "link": entry['link'],
-                    "pubDate": entry['pubDate'], "category": category, "filename": filename,
-                    "updated_date": datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-                })
+                new_items.append(new_item_row(
+                    entry['guid'], entry['title'], entry['link'], entry['pubDate'], category, filename,
+                    change_type="policy_update",
+                    change_summary="Detected from the TBS policy update feed.",
+                ))
+                doc_id_match = re.match(r"(\d+)", entry['guid'])
+                if doc_id_match:
+                    policy_issue_document_ids.add(doc_id_match.group(1))
+
+    print(f"Checking hierarchy tree at {HIERARCHY_URL}...")
+    previous_hierarchy = read_hierarchy_csv(HIERARCHY_CSV_PATH)
+    current_hierarchy = fetch_hierarchy_records(user_agent=USER_AGENT)
+    hierarchy_changes = compare_hierarchy(previous_hierarchy, current_hierarchy) if previous_hierarchy else {"added": [], "removed": []}
+    write_hierarchy_csv(HIERARCHY_CSV_PATH, current_hierarchy)
+    print(f"Captured {len(current_hierarchy)} hierarchy instruments.")
+
+    hierarchy_date = today_iso()
+    for record in hierarchy_changes["added"]:
+        doc_id = record["ID"]
+        print(f"Hierarchy addition found: {record['Name']} ({doc_id})")
+        filename = download_policy_xml(record["URL"], record.get("category", "Uncategorized"), record["Name"], hierarchy_date)
+        guid = f"{doc_id}_{hierarchy_date}"
+        new_items.append(new_item_row(
+            guid,
+            record["Name"],
+            record["URL"],
+            hierarchy_date,
+            record.get("category", "Uncategorized"),
+            filename or "",
+            change_type="hierarchy_added",
+            change_summary="Added to the TBS policy hierarchy tree.",
+            related_guid=doc_id,
+            source_id=doc_id,
+        ))
+        policy_issue_document_ids.add(doc_id)
+
+    for record in hierarchy_changes["removed"]:
+        doc_id = record["ID"]
+        print(f"Hierarchy removal found: {record['Name']} ({doc_id})")
+        new_items.append(new_item_row(
+            f"hierarchy_removed_{doc_id}_{hierarchy_date}",
+            f"Removed from hierarchy: {record['Name']}",
+            record.get("URL") or HIERARCHY_URL,
+            hierarchy_date,
+            "Hierarchy",
+            "",
+            change_type="hierarchy_removed",
+            change_summary="Removed from the TBS policy hierarchy tree.",
+            related_guid=doc_id,
+            source_id=doc_id,
+        ))
+
+    print("Checking policy glossary pages...")
+    previous_glossary_exists = os.path.exists(GLOSSARY_CSV_PATH) and os.path.getsize(GLOSSARY_CSV_PATH) > 0
+    previous_glossary = read_glossary_csv(GLOSSARY_CSV_PATH)
+    current_glossary = fetch_glossary_rows(user_agent=USER_AGENT)
+    glossary_changes = compare_glossary_rows(previous_glossary, current_glossary) if previous_glossary_exists else {"added": [], "removed": [], "changed": []}
+    glossary_payload = build_glossary_change_payload(glossary_changes)
+    write_glossary_csv(GLOSSARY_CSV_PATH, current_glossary)
+    write_glossary_markdown(GLOSSARY_MD_PATH, current_glossary)
+
+    changed_sources = glossary_payload["changes_by_source"]
+    if changed_sources:
+        write_json(GLOSSARY_CHANGES_JSON_PATH, glossary_payload)
+        print(f"Captured glossary changes for {len(changed_sources)} source instrument(s).")
+    elif os.path.exists(GLOSSARY_CHANGES_JSON_PATH):
+        os.remove(GLOSSARY_CHANGES_JSON_PATH)
+        print("Removed stale glossary change metadata.")
+    else:
+        print("No glossary term changes found.")
+
+    for source_id, payload in changed_sources.items():
+        if source_id in policy_issue_document_ids:
+            continue
+        source_title = payload.get("source_en") or payload.get("source_fr") or "Policy glossary"
+        guid = f"glossary_{source_id}_{hierarchy_date}"
+        change_count = len(payload["added"]) + len(payload["removed"]) + len(payload["changed"])
+        new_items.append(new_item_row(
+            guid,
+            f"Glossary terms for {source_title}",
+            GLOSSARY_URLS["en"],
+            hierarchy_date,
+            "Glossary",
+            "",
+            change_type="glossary",
+            change_summary=f"{change_count} glossary term change(s) detected for this source.",
+            related_guid=source_id,
+            source_id=source_id,
+        ))
 
     if not new_items:
         print("No new policy items found.")
@@ -291,14 +439,25 @@ def main():
 
     print(f"Found {len(new_items)} new items to add.")
     with open(NEW_ITEMS_CSV_PATH, 'w', newline='', encoding='utf-8') as f:
-        writer = csv.DictWriter(f, fieldnames=CSV_HEADERS); writer.writeheader(); writer.writerows(new_items)
+        writer = csv.DictWriter(f, fieldnames=NEW_ITEMS_CSV_HEADERS)
+        writer.writeheader()
+        writer.writerows([{header: row.get(header, "") for header in NEW_ITEMS_CSV_HEADERS} for row in new_items])
     print(f"Created {NEW_ITEMS_CSV_PATH} for issue creation.")
+
+    items_rows = [
+        {header: row.get(header, "") for header in CSV_HEADERS}
+        for row in new_items
+        if row.get("filename") and row.get("change_type") in {"policy_update", "hierarchy_added"}
+    ]
+    if not items_rows:
+        print("No policy document rows to append to items.csv.")
+        return
 
     file_exists = os.path.exists(ITEMS_CSV_PATH) and os.path.getsize(ITEMS_CSV_PATH) > 0
     with open(ITEMS_CSV_PATH, 'a', newline='', encoding='utf-8') as f:
         writer = csv.DictWriter(f, fieldnames=CSV_HEADERS)
         if not file_exists: writer.writeheader()
-        writer.writerows(new_items)
+        writer.writerows(items_rows)
     print("Successfully updated items.csv.")
 
 if __name__ == "__main__":

--- a/scripts/policy_sources.py
+++ b/scripts/policy_sources.py
@@ -1,0 +1,442 @@
+import csv
+import hashlib
+import html as html_lib
+import json
+import os
+import re
+from copy import copy
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+try:
+    from scripts.build_tbs_policy_hierarchy import build_full_records, extract_rows_with_hierarchy
+except ModuleNotFoundError:
+    from build_tbs_policy_hierarchy import build_full_records, extract_rows_with_hierarchy
+
+
+BASE_URL = "https://www.tbs-sct.canada.ca/pol/"
+DEFAULT_USER_AGENT = os.getenv("TBS_POLICY_HAWK_USER_AGENT", "TBS-Policy-Hawk/1.0 (+https://github.com/TBS-Policy-Hawk)")
+HIERARCHY_URL = urljoin(BASE_URL, "hierarch-eng.aspx")
+GLOSSARY_URLS = {
+    "en": urljoin(BASE_URL, "glossary-lexique-eng.aspx"),
+    "fr": urljoin(BASE_URL, "glossary-lexique-fra.aspx"),
+}
+HIERARCHY_HEADERS = ["ID", "URL", "Name", "Min Level", "Hierarchy Paths", "Other Names"]
+GLOSSARY_HEADERS = [
+    "source_id",
+    "source_en",
+    "source_fr",
+    "term_en",
+    "term_fr",
+    "def_en",
+    "def_fr",
+    "date_modified",
+]
+
+
+def clean_text(value):
+    text = html_lib.unescape(value or "")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def normalize_key(value):
+    return clean_text(value).casefold()
+
+
+def extract_doc_id(url):
+    match = re.search(r"[?&]id=(\d+)", url or "")
+    return match.group(1) if match else ""
+
+
+def page_date_modified(soup):
+    time_tag = soup.select_one('time[property="dateModified"]')
+    return clean_text(time_tag.get_text()) if time_tag else ""
+
+
+def infer_category(title):
+    title = title or ""
+    lowered = title.casefold()
+    if "directive" in lowered:
+        return "Directive"
+    if "policy framework" in lowered or "framework" in lowered:
+        return "Framework"
+    if "policy" in lowered:
+        return "Policy"
+    if "standard" in lowered:
+        return "Standard"
+    if "guideline" in lowered or "guidelines" in lowered:
+        return "Guidelines"
+    if "guide" in lowered:
+        return "Guide"
+    return "Uncategorized"
+
+
+def resolve_policy_url(url, getter=requests.get, user_agent=None):
+    headers = {"User-Agent": user_agent or DEFAULT_USER_AGENT}
+    response = getter(url, timeout=(5, 15), headers=headers, allow_redirects=True, stream=True)
+    try:
+        response.raise_for_status()
+        final_url = response.url or url
+        return final_url.replace("http://", "https://")
+    finally:
+        close = getattr(response, "close", None)
+        if close:
+            close()
+
+
+def fetch_hierarchy_records(getter=requests.get, user_agent=None, resolve_redirects=True):
+    headers = {"User-Agent": user_agent or DEFAULT_USER_AGENT}
+    response = getter(HIERARCHY_URL, timeout=60, headers=headers)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    date_modified = page_date_modified(soup)
+    records = build_full_records(extract_rows_with_hierarchy(response.text))
+
+    def resolve_record(record):
+        original_url = urljoin(BASE_URL, record["URL"])
+        if not resolve_redirects:
+            return record, original_url, original_url
+        try:
+            return record, original_url, resolve_policy_url(original_url, getter=getter, user_agent=user_agent)
+        except requests.RequestException as exc:
+            print(f"Warning: unable to resolve hierarchy link {original_url}: {exc}")
+            return record, original_url, original_url
+
+    resolved_records = []
+    if resolve_redirects:
+        with ThreadPoolExecutor(max_workers=12) as executor:
+            futures = [executor.submit(resolve_record, record) for record in records]
+            for future in as_completed(futures):
+                resolved_records.append(future.result())
+    else:
+        resolved_records = [resolve_record(record) for record in records]
+
+    by_id = {}
+    for record, original_url, resolved_url in resolved_records:
+        resolved_id = extract_doc_id(resolved_url) or record["ID"]
+        existing = by_id.get(resolved_id)
+        hierarchy_paths = set(filter(None, (record.get("Hierarchy Paths") or "").split(" || ")))
+        names = set(filter(None, [record.get("Name"), record.get("Other Names")]))
+
+        if existing:
+            existing_paths = set(filter(None, (existing["Hierarchy Paths"] or "").split(" || ")))
+            existing_names = set(filter(None, (existing["Other Names"] or "").split(", ")))
+            existing_paths.update(hierarchy_paths)
+            existing_names.update(names - {existing["Name"]})
+            existing["Hierarchy Paths"] = " || ".join(sorted(existing_paths))
+            existing["Other Names"] = ", ".join(sorted(existing_names))
+            existing["Min Level"] = str(min(int(existing["Min Level"]), int(record["Min Level"])))
+            continue
+
+        by_id[resolved_id] = {
+            "ID": resolved_id,
+            "URL": resolved_url,
+            "Name": record["Name"],
+            "Min Level": str(record["Min Level"]),
+            "Hierarchy Paths": " || ".join(sorted(hierarchy_paths)),
+            "Other Names": record.get("Other Names", ""),
+            "date_modified": date_modified,
+            "category": infer_category(record["Name"]),
+            "original_id": record["ID"],
+            "original_url": original_url,
+        }
+
+    return sorted(by_id.values(), key=lambda row: (int(row["Min Level"]), row["Name"]))
+
+
+def read_hierarchy_csv(path):
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        return []
+    with open(path, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def write_hierarchy_csv(path, records):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=HIERARCHY_HEADERS)
+        writer.writeheader()
+        for row in records:
+            writer.writerow({header: row.get(header, "") for header in HIERARCHY_HEADERS})
+
+
+def compare_hierarchy(previous, current):
+    previous_by_id = {row["ID"]: row for row in previous if row.get("ID")}
+    current_by_id = {row["ID"]: row for row in current if row.get("ID")}
+    previous_ids = set(previous_by_id)
+    current_ids = set(current_by_id)
+    return {
+        "added": [current_by_id[i] for i in sorted(current_ids - previous_ids)],
+        "removed": [previous_by_id[i] for i in sorted(previous_ids - current_ids)],
+    }
+
+
+def split_term(dt, lang):
+    dt_copy = copy(dt)
+    other_lang = "fr" if lang == "en" else "en"
+    translated = ""
+    for span in dt_copy.find_all(attrs={"lang": other_lang}):
+        translated = clean_text(span.get_text(" ", strip=True)) or translated
+        span.decompose()
+
+    primary = clean_text(dt_copy.get_text(" ", strip=True))
+    primary = re.sub(r"[\s\-\u2013\u2014]*\(\s*\)\s*$", "", primary).strip()
+    primary = re.sub(r"[\s\-\u2013\u2014]+$", "", primary).strip()
+
+    if lang == "en":
+        return primary, translated
+    return translated, primary
+
+
+def definition_text(dd):
+    dd_copy = copy(dd)
+    for footer in dd_copy.select("footer"):
+        footer.decompose()
+    return clean_text(dd_copy.get_text(" ", strip=True))
+
+
+def source_links(dd):
+    footer = dd.select_one("footer")
+    if not footer:
+        return [{"source_id": "", "source": ""}]
+
+    links = []
+    for link in footer.select("a[href*='doc-']"):
+        source_id = extract_doc_id(link.get("href", ""))
+        if source_id:
+            links.append({"source_id": source_id, "source": clean_text(link.get_text(" ", strip=True))})
+    return links or [{"source_id": "", "source": clean_text(footer.get_text(" ", strip=True))}]
+
+
+def parse_glossary_html(html, lang):
+    soup = BeautifulSoup(html, "html.parser")
+    date_modified = page_date_modified(soup)
+    rows = []
+
+    for dt in soup.select("main dt"):
+        dd = dt.find_next_sibling("dd")
+        if not dd:
+            continue
+        term_en, term_fr = split_term(dt, lang)
+        definition = definition_text(dd)
+        for source in source_links(dd):
+            row = {
+                "source_id": source["source_id"],
+                "source_en": source["source"] if lang == "en" else "",
+                "source_fr": source["source"] if lang == "fr" else "",
+                "term_en": term_en,
+                "term_fr": term_fr,
+                "def_en": definition if lang == "en" else "",
+                "def_fr": definition if lang == "fr" else "",
+                "date_modified": date_modified,
+            }
+            rows.append(row)
+    return rows
+
+
+def merge_glossary_rows(rows_en, rows_fr):
+    merged = {}
+    by_source_term_en = {}
+    by_source_term_fr = {}
+
+    def row_key(row):
+        digest = hashlib.sha1(
+            "||".join([
+                row.get("source_id", ""),
+                normalize_key(row.get("term_en", "")),
+                normalize_key(row.get("term_fr", "")),
+            ]).encode("utf-8")
+        ).hexdigest()[:12]
+        return digest
+
+    for row in rows_en:
+        key = row_key(row)
+        merged[key] = row.copy()
+        if row.get("term_en"):
+            by_source_term_en[(row.get("source_id", ""), normalize_key(row["term_en"]))] = key
+        if row.get("term_fr"):
+            by_source_term_fr[(row.get("source_id", ""), normalize_key(row["term_fr"]))] = key
+
+    for row in rows_fr:
+        key = None
+        if row.get("term_en"):
+            key = by_source_term_en.get((row.get("source_id", ""), normalize_key(row["term_en"])))
+        if not key and row.get("term_fr"):
+            key = by_source_term_fr.get((row.get("source_id", ""), normalize_key(row["term_fr"])))
+        if not key:
+            key = row_key(row)
+
+        existing = merged.setdefault(key, {header: "" for header in GLOSSARY_HEADERS})
+        for field in GLOSSARY_HEADERS:
+            if row.get(field) and not existing.get(field):
+                existing[field] = row[field]
+            elif field == "def_fr" and row.get(field):
+                existing[field] = row[field]
+            elif field == "source_fr" and row.get(field):
+                existing[field] = row[field]
+
+    rows = list(merged.values())
+    rows.sort(key=lambda r: (normalize_key(r.get("source_en") or r.get("source_fr")), normalize_key(r.get("term_en") or r.get("term_fr"))))
+    return rows
+
+
+def fetch_glossary_rows(getter=requests.get, user_agent=None):
+    headers = {"User-Agent": user_agent or DEFAULT_USER_AGENT}
+    parsed = {}
+    for lang, url in GLOSSARY_URLS.items():
+        response = getter(url, timeout=60, headers=headers)
+        response.raise_for_status()
+        parsed[lang] = parse_glossary_html(response.text, lang)
+    return merge_glossary_rows(parsed["en"], parsed["fr"])
+
+
+def read_glossary_csv(path):
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        return []
+    with open(path, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def write_glossary_csv(path, rows):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=GLOSSARY_HEADERS)
+        writer.writeheader()
+        writer.writerows([{header: row.get(header, "") for header in GLOSSARY_HEADERS} for row in rows])
+
+
+def write_glossary_markdown(path, rows):
+    lines = [
+        "# TBS Policy Glossary",
+        "",
+        "This file is generated from the English and French TBS policy glossary pages.",
+        "",
+    ]
+    current_source = None
+    for row in rows:
+        source = row.get("source_en") or row.get("source_fr") or "Unknown source"
+        if source != current_source:
+            if current_source is not None:
+                lines.append("")
+            lines.append(f"## {source}")
+            lines.append("")
+            current_source = source
+
+        term_en = row.get("term_en") or "n/a"
+        term_fr = row.get("term_fr") or "n/a"
+        lines.append(f"### {term_en} / {term_fr}")
+        if row.get("def_en"):
+            lines.append("")
+            lines.append(f"**EN:** {row['def_en']}")
+        if row.get("def_fr"):
+            lines.append("")
+            lines.append(f"**FR:** {row['def_fr']}")
+        if row.get("date_modified"):
+            lines.append("")
+            lines.append(f"_Glossary page date modified: {row['date_modified']}_")
+        lines.append("")
+
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def glossary_row_key(row):
+    return "||".join([
+        row.get("source_id", ""),
+        normalize_key(row.get("term_en", "")),
+        normalize_key(row.get("term_fr", "")),
+    ])
+
+
+def compare_glossary_rows(previous, current):
+    previous_by_key = {glossary_row_key(row): row for row in previous}
+    current_by_key = {glossary_row_key(row): row for row in current}
+    previous_keys = set(previous_by_key)
+    current_keys = set(current_by_key)
+
+    changed = []
+    compare_fields = ["source_en", "source_fr", "def_en", "def_fr", "date_modified"]
+    for key in sorted(previous_keys & current_keys):
+        old = previous_by_key[key]
+        new = current_by_key[key]
+        fields = [
+            field for field in compare_fields
+            if clean_text(old.get(field, "")) != clean_text(new.get(field, ""))
+        ]
+        if fields:
+            changed.append({"old": old, "new": new, "fields": fields})
+
+    return {
+        "added": [current_by_key[key] for key in sorted(current_keys - previous_keys)],
+        "removed": [previous_by_key[key] for key in sorted(previous_keys - current_keys)],
+        "changed": changed,
+    }
+
+
+def truncate(value, limit=500):
+    value = clean_text(value)
+    if len(value) <= limit:
+        return value
+    return value[: limit - 3].rstrip() + "..."
+
+
+def build_glossary_change_payload(changes):
+    grouped = {}
+
+    def bucket_for(row):
+        source_id = row.get("source_id") or "glossary"
+        return grouped.setdefault(
+            source_id,
+            {
+                "source_id": source_id,
+                "source_en": row.get("source_en", ""),
+                "source_fr": row.get("source_fr", ""),
+                "added": [],
+                "removed": [],
+                "changed": [],
+            },
+        )
+
+    for row in changes["added"]:
+        bucket_for(row)["added"].append({
+            "term_en": row.get("term_en", ""),
+            "term_fr": row.get("term_fr", ""),
+            "def_en": truncate(row.get("def_en", "")),
+            "def_fr": truncate(row.get("def_fr", "")),
+        })
+    for row in changes["removed"]:
+        bucket_for(row)["removed"].append({
+            "term_en": row.get("term_en", ""),
+            "term_fr": row.get("term_fr", ""),
+            "def_en": truncate(row.get("def_en", "")),
+            "def_fr": truncate(row.get("def_fr", "")),
+        })
+    for item in changes["changed"]:
+        row = item["new"]
+        old = item["old"]
+        bucket_for(row)["changed"].append({
+            "term_en": row.get("term_en", ""),
+            "term_fr": row.get("term_fr", ""),
+            "fields": item["fields"],
+            "old_def_en": truncate(old.get("def_en", "")),
+            "new_def_en": truncate(row.get("def_en", "")),
+            "old_def_fr": truncate(old.get("def_fr", "")),
+            "new_def_fr": truncate(row.get("def_fr", "")),
+        })
+
+    return {
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "changes_by_source": grouped,
+    }
+
+
+def write_json(path, payload):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")

--- a/tests/test_policy_sources.py
+++ b/tests/test_policy_sources.py
@@ -1,0 +1,139 @@
+import unittest
+
+from scripts import policy_sources
+from scripts import create_issues_with_screenshots
+
+
+class PolicySourcesHierarchyTests(unittest.TestCase):
+    def test_compares_hierarchy_additions_and_removals(self):
+        previous = [
+            {"ID": "1", "Name": "Old Policy", "URL": "https://example/old"},
+            {"ID": "2", "Name": "Existing Policy", "URL": "https://example/existing"},
+        ]
+        current = [
+            {"ID": "2", "Name": "Existing Policy", "URL": "https://example/existing"},
+            {"ID": "3", "Name": "New Directive", "URL": "https://example/new"},
+        ]
+
+        changes = policy_sources.compare_hierarchy(previous, current)
+
+        self.assertEqual([row["ID"] for row in changes["added"]], ["3"])
+        self.assertEqual([row["ID"] for row in changes["removed"]], ["1"])
+
+    def test_fetch_hierarchy_uses_redirected_document_id(self):
+        html = """
+        <html><body>
+        <main>
+          <ul class="tv-ul">
+            <li><a href="doc-eng.aspx?id=100">Old title, Policy on</a></li>
+          </ul>
+        </main>
+        <dl id="wb-dtmd"><dt>Date modified:</dt><dd><time property="dateModified">2026-07-01</time></dd></dl>
+        </body></html>
+        """
+
+        class FakeResponse:
+            def __init__(self, text="", url="https://www.tbs-sct.canada.ca/pol/hierarch-eng.aspx"):
+                self.text = text
+                self.url = url
+
+            def raise_for_status(self):
+                return None
+
+        def getter(url, **_kwargs):
+            if "hierarch-eng.aspx" in url:
+                return FakeResponse(html)
+            return FakeResponse("", "https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=200")
+
+        records = policy_sources.fetch_hierarchy_records(getter=getter, resolve_redirects=True)
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["ID"], "200")
+        self.assertEqual(records[0]["original_id"], "100")
+
+
+class PolicySourcesGlossaryTests(unittest.TestCase):
+    def test_parses_and_merges_bilingual_glossary_rows(self):
+        html_en = """
+        <main><dl>
+          <dt>access request (<span lang="fr"><i>demande d'accès</i></span>)</dt>
+          <dd>English definition.<footer><cite>Source: <a href="doc-eng.aspx?id=12453">Access to Information, Policy on</a></cite></footer></dd>
+        </dl></main>
+        <dl id="wb-dtmd"><dt>Date modified:</dt><dd><time property="dateModified">2026-07-01</time></dd></dl>
+        """
+        html_fr = """
+        <main><dl>
+          <dt>demande d'accès (<span lang="en"><i>access request</i></span>)</dt>
+          <dd>Définition française.<footer><cite>Source : <a href="doc-fra.aspx?id=12453">Politique sur l'accès à l'information</a></cite></footer></dd>
+        </dl></main>
+        <dl id="wb-dtmd"><dt>Date modified:</dt><dd><time property="dateModified">2026-07-01</time></dd></dl>
+        """
+
+        rows_en = policy_sources.parse_glossary_html(html_en, "en")
+        rows_fr = policy_sources.parse_glossary_html(html_fr, "fr")
+        rows = policy_sources.merge_glossary_rows(rows_en, rows_fr)
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["source_id"], "12453")
+        self.assertEqual(row["source_en"], "Access to Information, Policy on")
+        self.assertEqual(row["source_fr"], "Politique sur l'accès à l'information")
+        self.assertEqual(row["term_en"], "access request")
+        self.assertEqual(row["term_fr"], "demande d'accès")
+        self.assertEqual(row["def_en"], "English definition.")
+        self.assertEqual(row["def_fr"], "Définition française.")
+
+    def test_detects_glossary_definition_changes(self):
+        previous = [{
+            "source_id": "12453",
+            "source_en": "Access to Information, Policy on",
+            "source_fr": "",
+            "term_en": "access request",
+            "term_fr": "demande d'accès",
+            "def_en": "Old definition.",
+            "def_fr": "",
+            "date_modified": "2026-01-01",
+        }]
+        current = [{**previous[0], "def_en": "New definition."}]
+
+        changes = policy_sources.compare_glossary_rows(previous, current)
+        payload = policy_sources.build_glossary_change_payload(changes)
+
+        self.assertEqual(len(changes["changed"]), 1)
+        self.assertIn("12453", payload["changes_by_source"])
+        self.assertEqual(payload["changes_by_source"]["12453"]["changed"][0]["term_en"], "access request")
+
+
+class IssueBodyTests(unittest.TestCase):
+    def test_policy_issue_body_includes_related_glossary_changes(self):
+        row = {
+            "guid": "12453_2026-07-01",
+            "title": "Access to Information, Policy on",
+            "link": "https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=12453",
+            "category": "Policy",
+            "change_type": "policy_update",
+        }
+        glossary_changes = {
+            "12453": {
+                "source_en": "Access to Information, Policy on",
+                "source_fr": "Politique sur l'accès à l'information",
+                "added": [{"term_en": "new term", "term_fr": "nouveau terme"}],
+                "removed": [],
+                "changed": [],
+            }
+        }
+
+        body = create_issues_with_screenshots.issue_body_for_row(
+            row,
+            screenshot_success=False,
+            screenshot_url="",
+            glossary_changes=glossary_changes,
+        )
+
+        self.assertIn("A new or updated policy document has been detected.", body)
+        self.assertIn("### Glossary changes", body)
+        self.assertIn("new term", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Extend the periodic policy watch fetch to include the TBS policy hierarchy tree and treat hierarchy additions/removals as policy-update issue events.
- Add bilingual policy glossary capture from the EN/FR glossary pages, writing both CSV and Markdown outputs.
- Detect glossary term additions, removals, and definition/source changes, attaching them to related policy issues when present or creating dedicated glossary update issues otherwise.
- Add tests for hierarchy diffs, redirect handling, glossary parsing/merging, glossary change detection, and issue body rendering.

## Validation

- `python3 -m py_compile scripts/policy_sources.py scripts/fetch_feed.py scripts/create_issues_with_screenshots.py`
- `python3 -m unittest discover -s tests -v`
- `git diff --check`
- Live parser smoke test for hierarchy/glossary pages without mutating repository data.

## Notes

The remote repository does not have a `master` branch; the PR targets the default `main` branch.